### PR TITLE
Update `p-map`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"bluebird"
 	],
 	"dependencies": {
-		"p-map": "^2.0.0"
+		"p-map": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,12 @@ Minimum: `1`
 
 Number of concurrently pending promises returned by `mapper`.
 
+##### stopOnError
+
+Type: `boolean`\
+Default: `true`
+
+When set to `false`, instead of stopping when a promise rejects, it will wait for all the promises to settle and then reject with an [aggregated error](https://github.com/sindresorhus/aggregate-error) containing all the errors from the rejected promises.
 
 ## Related
 


### PR DESCRIPTION
Updating to the latest `p-map` brings the option `stopOnError`